### PR TITLE
feat: Add hint functionality to JigsawPuzzle component

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,20 +16,20 @@ module.exports = {
     ecmaVersion: 12
   },
   plugins: ['react', 'storybook', '@typescript-eslint', 'filename-rules'],
+  rules: {
+    '@typescript-eslint/no-use-before-define': 'error',
+    'filename-rules/match': [2, {
+      '.ts': 'kebab-case',
+      '.tsx': 'kebab-case'
+    }],
+    'no-console': ['error'],
+    'no-use-before-define': 'off',
+    'prefer-arrow-callback': 'error',
+    'react/prop-types': 0
+  },
   settings: {
     react: {
       version: 'detect'
     }
-  },
-  rules: {
-    'prefer-arrow-callback': 'error',
-    'no-use-before-define': 'off',
-    '@typescript-eslint/no-use-before-define': 'error',
-    'filename-rules/match': [2, {
-      '.tsx': 'kebab-case',
-      '.ts': 'kebab-case'
-    }],
-    'react/prop-types': 0,
-    'no-console': ['error']
   }
 }

--- a/src/jigsaw-puzzle.tsx
+++ b/src/jigsaw-puzzle.tsx
@@ -1,57 +1,81 @@
-import React, { FC, useCallback, useEffect, useRef, useState } from 'react'
+import React, { FC, useCallback, useEffect, useRef, useState } from "react";
 
 const clamp = (value: number, min: number, max: number) => {
-  if (value < min) { return min }
-  if (value > max) { return max }
-  return value
-}
+  if (value < min) {
+    return min;
+  }
+  if (value > max) {
+    return max;
+  }
+  return value;
+};
 
-const solveTolerancePercentage = 0.028
+const solveTolerancePercentage = 0.028;
 
 interface Tile {
-  tileOffsetX: number
-  tileOffsetY: number,
-  tileWidth: number,
-  tileHeight: number,
-  correctPosition: number,
-  currentPosXPerc: number,
-  currentPosYPerc: number,
-  solved: boolean
+  tileOffsetX: number;
+  tileOffsetY: number;
+  tileWidth: number;
+  tileHeight: number;
+  correctPosition: number;
+  currentPosXPerc: number;
+  currentPosYPerc: number;
+  solved: boolean;
+  random?: number;
 }
 
 export interface JigsawPuzzleProps {
   /** Source of the image. Can be any URL or relative path. */
-  imageSrc: string,
+  imageSrc: string;
   /** The amount of rows the puzzle will have. Defaults to 3. */
-  rows?: number,
+  rows?: number;
   /** The amount of columns the puzzle with have. Defaults to 4. */
-  columns?: number,
+  columns?: number;
   /* Called when the puzzle is solved. Defaults to an empty function. */
-  onSolved?: () => void
+  onSolved?: () => void;
+  /* Called when the hint button is clicked. Defaults to an empty function. */
+  hintCount?: number;
 }
 
 export const JigsawPuzzle: FC<JigsawPuzzleProps> = ({
   imageSrc,
   rows = 3,
   columns = 4,
-  onSolved = () => {}
+  onSolved = () => {},
+  hintCount = 0,
 }) => {
   if (!imageSrc) {
-    return null
+    return null;
   }
-  const [tiles, setTiles] = useState<Tile[] | undefined>()
-  const [imageSize, setImageSize] = useState<{ width: number, height: number }>()
-  const [rootSize, setRootSize] = useState<{ width: number, height: number }>()
-  const [calculatedHeight, setCalculatedHeight] = useState<number>()
-  const rootElement = useRef<HTMLElement>()
-  const resizeObserver = useRef<ResizeObserver>()
-  const draggingTile = useRef<{ tile: Tile, elem: HTMLElement, mouseOffsetX: number, mouseOffsetY: number } | undefined>()
-  const onImageLoaded = useCallback((image: HTMLImageElement) => {
-    setImageSize({ width: image.width, height: image.height })
-    if (rootSize) { setCalculatedHeight(rootSize!.width / image.width * image.height) }
-    setTiles(
-      Array.from(Array(rows * columns).keys())
-        .map(position => ({
+  const [tiles, setTiles] = useState<Tile[]>();
+  const [imageSize, setImageSize] = useState<{
+    width: number;
+    height: number;
+  }>();
+  const [rootSize, setRootSize] = useState<{ width: number; height: number }>();
+  const [calculatedHeight, setCalculatedHeight] = useState<number>();
+  const rootElement = useRef<HTMLElement>(null);
+  /* Store the previous hint count */
+  const prevHintCount = useRef<number>(hintCount);
+  const resizeObserver = useRef<ResizeObserver>();
+  const draggingTile = useRef<
+    | {
+        tile: Tile;
+        elem: HTMLElement;
+        mouseOffsetX: number;
+        mouseOffsetY: number;
+      }
+    | undefined
+  >();
+
+  const onImageLoaded = useCallback(
+    (image: HTMLImageElement) => {
+      setImageSize({ width: image.width, height: image.height });
+      if (rootSize) {
+        setCalculatedHeight((rootSize!.width / image.width) * image.height);
+      }
+      setTiles(
+        Array.from(Array(rows * columns).keys()).map((position) => ({
           correctPosition: position,
           tileHeight: image.height / rows,
           tileWidth: image.width / columns,
@@ -59,160 +83,307 @@ export const JigsawPuzzle: FC<JigsawPuzzleProps> = ({
           tileOffsetY: Math.floor(position / columns) * (image.height / rows),
           currentPosXPerc: Math.random() * (1 - 1 / rows),
           currentPosYPerc: Math.random() * (1 - 1 / columns),
-          solved: false
+          solved: false,
         }))
-    )
-  }, [rows, columns])
+      );
+    },
+    [rows, columns]
+  );
 
-  const onRootElementResized = useCallback((args: ResizeObserverEntry[]) => {
-    const contentRect = args.find(it => it.contentRect)?.contentRect
-    if (contentRect) {
-      setRootSize({
-        width: contentRect.width,
-        height: contentRect.height
-      })
-      if (imageSize) {
-        setCalculatedHeight(contentRect.width / imageSize!.width * imageSize!.height)
+  const onRootElementResized = useCallback(
+    (args: ResizeObserverEntry[]) => {
+      const contentRect = args.find((it) => it.contentRect)?.contentRect;
+      if (contentRect) {
+        setRootSize({
+          width: contentRect.width,
+          height: contentRect.height,
+        });
+        if (imageSize) {
+          setCalculatedHeight(
+            (contentRect.width / imageSize!.width) * imageSize!.height
+          );
+        }
       }
-    }
-  }, [setRootSize, imageSize])
+    },
+    [setRootSize, imageSize]
+  );
 
-  const onRootElementRendered = useCallback((element: HTMLElement | null) => {
-    if (element) {
-      rootElement.current = element
-      const observer = new ResizeObserver(onRootElementResized)
-      observer.observe(element)
-      resizeObserver.current = observer
-      setRootSize({
-        width: element.offsetWidth,
-        height: element.offsetHeight
-      })
-      if (imageSize) { setCalculatedHeight(element.offsetWidth / imageSize.width * imageSize.height) }
-    }
-  }, [setRootSize, imageSize, rootElement, resizeObserver])
+  const onRootElementRendered = useCallback(
+    (element: HTMLElement | null) => {
+      if (element) {
+        rootElement.current = element;
+        const observer = new ResizeObserver(onRootElementResized);
+        observer.observe(element);
+        resizeObserver.current = observer;
+        setRootSize({
+          width: element.offsetWidth,
+          height: element.offsetHeight,
+        });
+        if (imageSize) {
+          setCalculatedHeight(
+            (element.offsetWidth / imageSize.width) * imageSize.height
+          );
+        }
+      }
+    },
+    [setRootSize, imageSize, rootElement, resizeObserver]
+  );
 
   useEffect(() => {
-    const image = new Image()
-    image.onload = () => onImageLoaded(image)
-    image.src = imageSrc
-  }, [imageSrc, rows, columns])
+    const image = new Image();
+    image.onload = () => onImageLoaded(image);
+    image.src = imageSrc;
+  }, [imageSrc, rows, columns]);
 
-  const onTileMouseDown = useCallback((tile: Tile, event: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>) => {
-    if (!tile.solved) {
-      if (event.type === 'touchstart') {
-        document.documentElement.style.setProperty('overflow', 'hidden')
-      }
-
-      const eventPos = {
-        x: (event as React.MouseEvent).pageX ?? (event as React.TouchEvent).touches[0].pageX,
-        y: (event as React.MouseEvent).pageY ?? (event as React.TouchEvent).touches[0].pageY
-      }
-      draggingTile.current = {
-        tile,
-        elem: event.target as HTMLDivElement,
-        mouseOffsetX: eventPos.x - (event.target as HTMLDivElement).getBoundingClientRect().x,
-        mouseOffsetY: eventPos.y - (event.target as HTMLDivElement).getBoundingClientRect().y
-      };
-      (event.target as HTMLDivElement).classList.add('jigsaw-puzzle__piece--dragging')
-    }
-  }, [draggingTile])
-
-  const onRootMouseMove = useCallback((event: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>) => {
-    if (draggingTile.current) {
-      event.stopPropagation()
-      event.preventDefault()
-      const eventPos = {
-        x: (event as React.MouseEvent).pageX ?? (event as React.TouchEvent).touches[0].pageX,
-        y: (event as React.MouseEvent).pageY ?? (event as React.TouchEvent).touches[0].pageY
-      }
-      const draggedToRelativeToRoot = {
-        x: clamp(
-          eventPos.x - rootElement.current!.getBoundingClientRect().left - draggingTile.current.mouseOffsetX,
-          0,
-          rootSize!.width - draggingTile.current.elem.offsetWidth
-        ),
-        y: clamp(
-          eventPos.y - rootElement.current!.getBoundingClientRect().top - draggingTile.current.mouseOffsetY,
-          0,
-          rootSize!.height - draggingTile.current.elem.offsetHeight
-        )
-      }
-      draggingTile.current.elem.style.setProperty('left', `${draggedToRelativeToRoot.x}px`)
-      draggingTile.current.elem.style.setProperty('top', `${draggedToRelativeToRoot.y}px`)
-    }
-  }, [draggingTile, rootSize])
-  const onRootMouseUp = useCallback((event: React.TouchEvent | React.MouseEvent) => {
-    if (draggingTile.current) {
-      if (event.type === 'touchend') {
-        document.documentElement.style.removeProperty('overflow')
-      }
-      draggingTile.current?.elem.classList.remove('jigsaw-puzzle__piece--dragging')
-      const draggedToPercentage = {
-        x: clamp(draggingTile.current!.elem.offsetLeft / rootSize!.width, 0, 1),
-        y: clamp(draggingTile.current!.elem.offsetTop / rootSize!.height, 0, 1)
-      }
-      const draggedTile = draggingTile.current.tile
-      const targetPositionPercentage = {
-        x: draggedTile.correctPosition % columns / columns,
-        y: Math.floor(draggedTile.correctPosition / columns) / rows
-      }
-      const isSolved = Math.abs(targetPositionPercentage.x - draggedToPercentage.x) <= solveTolerancePercentage &&
-        Math.abs(targetPositionPercentage.y - draggedToPercentage.y) <= solveTolerancePercentage
-
-      setTiles(prevState => {
-        const newState = [
-          ...prevState!.filter(it => it.correctPosition !== draggedTile.correctPosition),
-          {
-            ...draggedTile,
-            currentPosXPerc: !isSolved ? draggedToPercentage.x : targetPositionPercentage.x,
-            currentPosYPerc: !isSolved ? draggedToPercentage.y : targetPositionPercentage.y,
-            solved: isSolved
-          }
-        ]
-        if (newState.every(tile => tile.solved)) {
-          onSolved()
+  const onTileMouseDown = useCallback(
+    (
+      tile: Tile,
+      event: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>
+    ) => {
+      if (!tile.solved) {
+        if (event.type === "touchstart") {
+          document.documentElement.style.setProperty("overflow", "hidden");
         }
-        return newState
-      })
-      draggingTile.current = undefined
-    }
-  }, [draggingTile, setTiles, rootSize, onSolved])
 
-  return <div ref={onRootElementRendered}
-              onTouchMove={onRootMouseMove}
-              onMouseMove={onRootMouseMove}
-              onTouchEnd={onRootMouseUp}
-              onMouseUp={onRootMouseUp}
-              onTouchCancel={onRootMouseUp}
-              onMouseLeave={onRootMouseUp}
-              className="jigsaw-puzzle"
-              style={{ height: !calculatedHeight ? undefined : `${calculatedHeight}px` }}
-              onDragEnter={event => {
-                event.stopPropagation()
-                event.preventDefault()
-              }}
-              onDragOver={event => {
-                event.stopPropagation()
-                event.preventDefault()
-              }}
+        const eventPos = {
+          x:
+            (event as React.MouseEvent).pageX ??
+            (event as React.TouchEvent).touches[0].pageX,
+          y:
+            (event as React.MouseEvent).pageY ??
+            (event as React.TouchEvent).touches[0].pageY,
+        };
+        draggingTile.current = {
+          tile,
+          elem: event.target as HTMLDivElement,
+          mouseOffsetX:
+            eventPos.x -
+            (event.target as HTMLDivElement).getBoundingClientRect().x,
+          mouseOffsetY:
+            eventPos.y -
+            (event.target as HTMLDivElement).getBoundingClientRect().y,
+        };
+        (event.target as HTMLDivElement).classList.add(
+          "jigsaw-puzzle__piece--dragging"
+        );
+      }
+    },
+    [draggingTile]
+  );
+
+  const onRootMouseMove = useCallback(
+    (
+      event: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>
+    ) => {
+      if (draggingTile.current) {
+        event.stopPropagation();
+        event.preventDefault();
+        const eventPos = {
+          x:
+            (event as React.MouseEvent).pageX ??
+            (event as React.TouchEvent).touches[0].pageX,
+          y:
+            (event as React.MouseEvent).pageY ??
+            (event as React.TouchEvent).touches[0].pageY,
+        };
+        const draggedToRelativeToRoot = {
+          x: clamp(
+            eventPos.x -
+              rootElement.current!.getBoundingClientRect().left -
+              draggingTile.current.mouseOffsetX,
+            0,
+            rootSize!.width - draggingTile.current.elem.offsetWidth
+          ),
+          y: clamp(
+            eventPos.y -
+              rootElement.current!.getBoundingClientRect().top -
+              draggingTile.current.mouseOffsetY,
+            0,
+            rootSize!.height - draggingTile.current.elem.offsetHeight
+          ),
+        };
+        draggingTile.current.elem.style.setProperty(
+          "left",
+          `${draggedToRelativeToRoot.x}px`
+        );
+        draggingTile.current.elem.style.setProperty(
+          "top",
+          `${draggedToRelativeToRoot.y}px`
+        );
+      }
+    },
+    [draggingTile, rootSize]
+  );
+  const onRootMouseUp = useCallback(
+    (event: React.TouchEvent | React.MouseEvent) => {
+      if (draggingTile.current) {
+        if (event.type === "touchend") {
+          document.documentElement.style.removeProperty("overflow");
+        }
+        draggingTile.current?.elem.classList.remove(
+          "jigsaw-puzzle__piece--dragging"
+        );
+        const draggedToPercentage = {
+          x: clamp(
+            draggingTile.current!.elem.offsetLeft / rootSize!.width,
+            0,
+            1
+          ),
+          y: clamp(
+            draggingTile.current!.elem.offsetTop / rootSize!.height,
+            0,
+            1
+          ),
+        };
+        const draggedTile = draggingTile.current.tile;
+        const targetPositionPercentage = {
+          x: (draggedTile.correctPosition % columns) / columns,
+          y: Math.floor(draggedTile.correctPosition / columns) / rows,
+        };
+        const isSolved =
+          Math.abs(targetPositionPercentage.x - draggedToPercentage.x) <=
+            solveTolerancePercentage &&
+          Math.abs(targetPositionPercentage.y - draggedToPercentage.y) <=
+            solveTolerancePercentage;
+
+        setTiles((prevState) => {
+          const newState = [
+            ...prevState!.filter(
+              (it) => it.correctPosition !== draggedTile.correctPosition
+            ),
+            {
+              ...draggedTile,
+              currentPosXPerc: !isSolved
+                ? draggedToPercentage.x
+                : targetPositionPercentage.x,
+              currentPosYPerc: !isSolved
+                ? draggedToPercentage.y
+                : targetPositionPercentage.y,
+              solved: isSolved,
+            },
+          ];
+          if (newState.every((tile) => tile.solved)) {
+            onSolved();
+          }
+          return newState;
+        });
+        draggingTile.current = undefined;
+      }
+    },
+    [draggingTile, setTiles, rootSize, onSolved]
+  );
+
+/* Hint functionality */
+useEffect(() => {
+  if (hintCount > prevHintCount.current) {
+    // Maximum number of tiles to move per hint
+    const maxTilesMovement = 1; 
+    const hintsUsed = Math.min(
+      hintCount - prevHintCount.current,
+      maxTilesMovement
+    );
+
+    setTiles((prevTiles) => {
+      // Find unsolved tiles
+      const unsolvedTiles = prevTiles?.filter((tile) => !tile.solved) || [];
+      // Shuffle the unsolved tiles To be solkved in random order when hint is called
+      const shuffledTiles = unsolvedTiles
+        .map((tile) => ({ tile, sort: Math.random() }))
+        .sort((a, b) => a.sort - b.sort)
+        .map((obj) => obj.tile);
+
+      const tilesToSolve = shuffledTiles.slice(0, hintsUsed);
+      return prevTiles?.map((tile) => {
+        if (
+          tilesToSolve.some(
+            (t) => t.correctPosition === tile.correctPosition
+          )
+        ) {
+          const targetPositionPercentage = {
+            x: (tile.correctPosition % columns) / columns,
+            y: Math.floor(tile.correctPosition / columns) / rows,
+          };
+          return {
+            ...tile,
+            currentPosXPerc: targetPositionPercentage.x,
+            currentPosYPerc: targetPositionPercentage.y,
+            solved: true,
+          };
+        }
+        return tile;
+      });
+    });
+    // Update the previous hint count
+    prevHintCount.current = hintCount;
+  }
+}, [hintCount, columns, rows]);
+
+// Check if all tiles are solved and call onSolved
+useEffect(() => {
+  if (tiles && tiles.length > 0 && tiles.every((tile) => tile.solved)) {
+    onSolved();
+  }
+}, [tiles, onSolved]);
+
+// Checking if the puzzle peices are solved before handeling the hint functionality
+useEffect(() => {
+  if (tiles && tiles.length > 0 && tiles.every((tile) => tile.solved)) {
+    onSolved();
+  }
+}, [tiles, onSolved]);
+
+
+return (
+  <div
+    ref={onRootElementRendered}
+    onTouchMove={onRootMouseMove}
+    onMouseMove={onRootMouseMove}
+    onTouchEnd={onRootMouseUp}
+    onMouseUp={onRootMouseUp}
+    onTouchCancel={onRootMouseUp}
+    onMouseLeave={onRootMouseUp}
+    className="jigsaw-puzzle"
+    style={{
+      height: calculatedHeight ? `${calculatedHeight}px` : undefined,
+    }}
+    onDragEnter={(event) => {
+      event.stopPropagation();
+      event.preventDefault();
+    }}
+    onDragOver={(event) => {
+      event.stopPropagation();
+      event.preventDefault();
+    }}
   >
-    {tiles && rootSize && imageSize && tiles.map(tile =>
-      <div
-        draggable={false}
-        onMouseDown={event => onTileMouseDown(tile, event)}
-        onTouchStart={event => onTileMouseDown(tile, event)}
-        key={tile.correctPosition}
-        className={`jigsaw-puzzle__piece ${tile.solved ? ' jigsaw-puzzle__piece--solved' : ''} `}
-        style={{
-          position: 'absolute',
-          height: `${1 / rows * 100}%`,
-          width: `${1 / columns * 100}%`,
-          backgroundImage: `url(${imageSrc})`,
-          backgroundSize: `${rootSize.width}px ${rootSize.height}px`,
-          backgroundPositionX: `${tile.correctPosition % columns / (columns - 1) * 100}%`,
-          backgroundPositionY: `${Math.floor(tile.correctPosition / columns) / (rows - 1) * 100}%`,
-          left: `${tile.currentPosXPerc * rootSize.width}px`,
-          top: `${tile.currentPosYPerc * rootSize.height}px`
-        }}/>)}
+    {tiles &&
+      rootSize &&
+      imageSize &&
+      tiles.map((tile) => (
+        <div
+          draggable={false}
+          onMouseDown={(event) => onTileMouseDown(tile, event)}
+          onTouchStart={(event) => onTileMouseDown(tile, event)}
+          key={tile.correctPosition}
+          className={`jigsaw-puzzle__piece ${
+            tile.solved ? " jigsaw-puzzle__piece--solved" : ""
+          } `}
+          style={{
+            position: "absolute",
+            height: `${(1 / rows) * 100}%`,
+            width: `${(1 / columns) * 100}%`,
+            backgroundImage: `url(${imageSrc})`,
+            backgroundSize: `${rootSize.width}px ${rootSize.height}px`,
+            backgroundPositionX: `${
+              ((tile.correctPosition % columns) / (columns - 1)) * 100
+            }%`,
+            backgroundPositionY: `${
+              (Math.floor(tile.correctPosition / columns) / (rows - 1)) * 100
+            }%`,
+            left: `${tile.currentPosXPerc * rootSize.width}px`,
+            top: `${tile.currentPosYPerc * rootSize.height}px`,
+          }}
+        />
+      ))}
   </div>
-}
+);
+}; 

--- a/src/stories/jigsaw-puzzle.stories.tsx
+++ b/src/stories/jigsaw-puzzle.stories.tsx
@@ -24,7 +24,13 @@ const meta: Meta<typeof JigsawPuzzle> = {
     onSolved: {
       description: 'Called when the puzzle is solved.',
       action: 'solved'
-    }
+    },
+    hintCount: {
+      defaultValue: 0,
+      description: 'The number of hints used. Increase to reveal hints.',
+      type: 'number',
+      control: { type: 'number' },
+    },
   }
 }
 
@@ -34,6 +40,7 @@ type Story = StoryObj<typeof JigsawPuzzle>
 
 export const Puzzle: Story = {
   args: {
-    imageSrc: 'https://images.unsplash.com/photo-1595045051853-05ef47bdfdbe?3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80'
+    imageSrc: 'https://images.unsplash.com/photo-1595045051853-05ef47bdfdbe?3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80',
+    hintCount: 0,
   }
 }

--- a/src/stories/jigsaw-puzzle.stories.tsx
+++ b/src/stories/jigsaw-puzzle.stories.tsx
@@ -1,37 +1,36 @@
-import { Meta, StoryObj } from '@storybook/react'
+import type { Meta, StoryObj } from '@storybook/react'
 import { JigsawPuzzle } from '../'
 import '../jigsaw-puzzle.css'
 import './jigsaw-puzzle.css'
-
 const meta: Meta<typeof JigsawPuzzle> = {
-  component: JigsawPuzzle,
-  title: 'react-jigsaw-puzzle',
   argTypes: {
-    imageSrc: {
-      description: 'Source of the image. Can be any URL or relative path.',
-      type: 'string'
-    },
-    rows: {
-      defaultValue: 3,
-      description: 'The amount of rows the puzzle will have.',
-      type: 'number'
-    },
     columns: {
       defaultValue: 4,
       description: 'The amount of columns the puzzle with have.',
       type: 'number'
     },
-    onSolved: {
-      description: 'Called when the puzzle is solved.',
-      action: 'solved'
-    },
     hintCount: {
+      control: { type: 'number' },
       defaultValue: 0,
       description: 'The number of hints used. Increase to reveal hints.',
-      type: 'number',
-      control: { type: 'number' },
+      type: 'number'
     },
-  }
+    imageSrc: {
+      description: 'Source of the image. Can be any URL or relative path.',
+      type: 'string'
+    },
+    onSolved: {
+      action: 'solved',
+      description: 'Called when the puzzle is solved.'
+    },
+    rows: {
+      defaultValue: 3,
+      description: 'The amount of rows the puzzle will have.',
+      type: 'number'
+    }
+  },
+  component: JigsawPuzzle,
+  title: 'react-jigsaw-puzzle'
 }
 
 export default meta
@@ -40,7 +39,7 @@ type Story = StoryObj<typeof JigsawPuzzle>
 
 export const Puzzle: Story = {
   args: {
-    imageSrc: 'https://images.unsplash.com/photo-1595045051853-05ef47bdfdbe?3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80',
     hintCount: 0,
+    imageSrc: 'https://images.unsplash.com/photo-1595045051853-05ef47bdfdbe?3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80'
   }
 }


### PR DESCRIPTION
- Introduced 'hintCount' prop to enable hint functionality.
- Updated the JigsawPuzzle component to reveal tiles when 'hintCount' increases.
- Modified stories.tsx to include 'hintCount' in argTypes and default args.
- Ensured that the puzzle was checked for completion after applying hints.
- Added documentation and controls for 'hintCount' in Storybook.


I recently worked on a custom game project where we were looking for puzzle libraries. I found one that seemed promising, but unfortunately, it didn't have the hint feature we needed. It took me some time to extract the main code from the node_modules and rework it a bit to add the hint feature, allowing it to be passed as a prop and used for providing hints in the game. I'm looking forward to having more open discussions about this. If there's anything missing or if you have questions, please let me know. It was really fun to work on this!